### PR TITLE
:sparkles: support non-kcp environment

### DIFF
--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -138,7 +138,12 @@ func (c *CacheReader) List(ctx context.Context, out client.ObjectList, opts ...c
 		// namespace.
 		objs, err = c.indexer.ByIndex(FieldIndexName(field), KeyToNamespacedKey(listOpts.Namespace, val))
 	case listOpts.Cluster.Empty():
-		objs = c.indexer.List()
+		switch {
+		case listOpts.Namespace != "":
+			objs, err = c.indexer.ByIndex(cache.NamespaceIndex, listOpts.Namespace)
+		default:
+			objs = c.indexer.List()
+		}
 	case listOpts.Namespace != "":
 		objs, err = c.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ToClusterAwareKey(listOpts.Cluster.String(), listOpts.Namespace, ""))
 	default:


### PR DESCRIPTION
If the cluster name is not available, then assume that it's running against a normal cluster and using the standard indexes.

related PRs:
* https://github.com/kcp-dev/controller-runtime-example/pull/8
* https://github.com/kcp-dev/apimachinery/pull/35
fixes: https://github.com/kcp-dev/apimachinery/issues/32