### PR TITLE
✨ update logical cluster version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/logr v1.2.0
 	github.com/go-logr/zapr v1.2.0
 	github.com/kcp-dev/apimachinery v0.0.0-20220708220956-c302aeddfde7
-	github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5
+	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,7 +298,10 @@ github.com/kcp-dev/apimachinery v0.0.0-20220708220956-c302aeddfde7 h1:ManYmc0CcV
 github.com/kcp-dev/apimachinery v0.0.0-20220708220956-c302aeddfde7/go.mod h1:+HKR4Ohhcq0TzLFnbH/iZkClN2HA6YZT5i1J7waX0OQ=
 github.com/kcp-dev/logicalcluster v1.0.0 h1:qCnoUNaqJ0Tgefkj3vXn17EC76AP44WZwnIuHLw6yGQ=
 github.com/kcp-dev/logicalcluster v1.0.0/go.mod h1:M0CBFkJTW29XtIP5XIkDfhYQ8LU6HrnseRb4zmgBltE=
+github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5 h1:ygcM+nvb7QBB/o3HZVw5sYu6KH9aXcrZ+A+IjEDAabA=
 github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5/go.mod h1:M0CBFkJTW29XtIP5XIkDfhYQ8LU6HrnseRb4zmgBltE=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.0 h1:pZqnHuK0+lD8FboE36hvTOuRZp6B/K5xo3RkRJZFYRo=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.0/go.mod h1:XcflOqXnekjSmsrsDPxu6wImo4xvtd6jQYl/ysoPh28=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.sum
+++ b/go.sum
@@ -292,12 +292,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kcp-dev/apimachinery v0.0.0-20220621200107-3d03cbbc3770 h1:vO2xIamfv7laTXwf8x+WZKugB1JTF62gHZgf+D0OY9E=
-github.com/kcp-dev/apimachinery v0.0.0-20220621200107-3d03cbbc3770/go.mod h1:FIzhTU6DM3HYZhGv8w/1S/mbmSv1HzulZpjr/1/6i/I=
 github.com/kcp-dev/apimachinery v0.0.0-20220708220956-c302aeddfde7 h1:ManYmc0CcVDDQAMJDsab0p7aIWKOxzKTmK8LVyMs1Bs=
 github.com/kcp-dev/apimachinery v0.0.0-20220708220956-c302aeddfde7/go.mod h1:+HKR4Ohhcq0TzLFnbH/iZkClN2HA6YZT5i1J7waX0OQ=
-github.com/kcp-dev/logicalcluster v1.0.0 h1:qCnoUNaqJ0Tgefkj3vXn17EC76AP44WZwnIuHLw6yGQ=
-github.com/kcp-dev/logicalcluster v1.0.0/go.mod h1:M0CBFkJTW29XtIP5XIkDfhYQ8LU6HrnseRb4zmgBltE=
 github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5 h1:ygcM+nvb7QBB/o3HZVw5sYu6KH9aXcrZ+A+IjEDAabA=
 github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5/go.mod h1:M0CBFkJTW29XtIP5XIkDfhYQ8LU6HrnseRb4zmgBltE=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.0 h1:pZqnHuK0+lD8FboE36hvTOuRZp6B/K5xo3RkRJZFYRo=

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	"github.com/kcp-dev/logicalcluster"
+	"github.com/kcp-dev/logicalcluster/v2"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -17,7 +17,7 @@ limitations under the License.
 package client
 
 import (
-	"github.com/kcp-dev/logicalcluster"
+	"github.com/kcp-dev/logicalcluster/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -17,7 +17,7 @@ limitations under the License.
 package handler
 
 import (
-	"github.com/kcp-dev/logicalcluster"
+	"github.com/kcp-dev/logicalcluster/v2"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -19,7 +19,7 @@ package handler
 import (
 	"fmt"
 
-	"github.com/kcp-dev/logicalcluster"
+	"github.com/kcp-dev/logicalcluster/v2"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Update logical cluster version.
Fixes https://github.com/kcp-dev/controller-runtime/issues/18.