### PR TITLE
UPSTREAM: <carry>: Support cluster-aware APIReader client

### DIFF
--- a/pkg/kcp/wrappers.go
+++ b/pkg/kcp/wrappers.go
@@ -43,6 +43,10 @@ func NewClusterAwareManager(cfg *rest.Config, options ctrl.Options) (manager.Man
 		options.NewCache = NewClusterAwareCache
 	}
 
+	if options.NewAPIReader == nil {
+		options.NewAPIReader = NewClusterAwareAPIReader
+	}
+
 	if options.NewClient == nil {
 		options.NewClient = NewClusterAwareClient
 	}
@@ -65,6 +69,29 @@ func NewClusterAwareCache(config *rest.Config, opts cache.Options) (cache.Cache,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc,
 	}
 	return cache.New(c, opts)
+}
+
+// NewClusterAwareAPIReader returns a client.Reader that provides read-only access to the API server,
+// and is configured to use the context to scope requests to the proper cluster. To scope requests,
+// pass the request context with the cluster set.
+// Example:
+//	import (
+//		"context"
+//		kcpclient "github.com/kcp-dev/apimachinery/pkg/client"
+//		ctrl "sigs.k8s.io/controller-runtime"
+//	)
+//	func (r *reconciler)  Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//		ctx = kcpclient.WithCluster(ctx, req.ObjectKey.Cluster)
+//		// from here on pass this context to all client calls
+//		...
+//	}
+func NewClusterAwareAPIReader(config *rest.Config, opts client.Options) (client.Reader, error) {
+	httpClient, err := ClusterAwareHTTPClient(config)
+	if err != nil {
+		return nil, err
+	}
+	opts.HTTPClient = httpClient
+	return cluster.DefaultNewAPIReader(config, opts)
 }
 
 // NewClusterAwareClient returns a client.Client that is configured to use the context

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -234,6 +234,11 @@ type Options struct {
 	// by the manager. If not set this will use the default new cache function.
 	NewCache cache.NewCacheFunc
 
+	// NewAPIReaderFunc is the function that creates the APIReader client to be
+	// used by the manager. If not set this will use the default new APIReader
+	// function.
+	NewAPIReader cluster.NewAPIReaderFunc
+
 	// NewClient is the func that creates the client to be used by the manager.
 	// If not set this will create the default DelegatingClient that will
 	// use the cache for reads and the client for writes.
@@ -326,6 +331,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		clusterOptions.SyncPeriod = options.SyncPeriod
 		clusterOptions.Namespace = options.Namespace
 		clusterOptions.NewCache = options.NewCache
+		clusterOptions.NewAPIReader = options.NewAPIReader
 		clusterOptions.NewClient = options.NewClient
 		clusterOptions.ClientDisableCacheFor = options.ClientDisableCacheFor
 		clusterOptions.DryRunClient = options.DryRunClient


### PR DESCRIPTION
Fixes #23.