### PR TITLE
Add context Cluster helpers, round tripper to cluster aware

### DIFF
--- a/pkg/kcp/context.go
+++ b/pkg/kcp/context.go
@@ -1,0 +1,24 @@
+package kcp
+
+import (
+	"context"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+type key int
+
+const (
+	keyCluster key = iota
+)
+
+// WithCluster injects a cluster name into a context.
+func WithCluster(ctx context.Context, cluster logicalcluster.Name) context.Context {
+	return context.WithValue(ctx, keyCluster, cluster)
+}
+
+// ClusterFromContext extracts a cluster name from the context.
+func ClusterFromContext(ctx context.Context) (logicalcluster.Name, bool) {
+	s, ok := ctx.Value(keyCluster).(logicalcluster.Name)
+	return s, ok
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@redhat.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
