### PR TITLE
🌱 Migrate existing CI job to prow

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,13 @@
+presubmits:
+  - name: pull-controller-runtime-everything
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/controller-runtime.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - test


### PR DESCRIPTION
Existing CI runs check-existing.sh (called by
make test). This commit migrates to a prow presubmit called pull-controller-runtime-everything.

Fixes https://github.com/kcp-dev/infra/issues/30
Prev: https://github.com/kcp-dev/controller-runtime/pull/38
Opening new PR against kcp-1.26

/assign @xrstf