### PR TITLE
✨ Rebase kcp modifications onto v0.16.2

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,13 @@
+presubmits:
+  - name: pull-controller-runtime-everything
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/controller-runtime.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.20.9-1
+          command:
+            - make
+            - test

--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - davidfestal
+  - ncdc
+  - stevekuznetsov
+  - sttts
+reviewers:
+  - fabianvf
+  - varshaprasad96

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,11 @@ $(GO_APIDIFF): $(TOOLS_DIR)/go.mod # Build go-apidiff from tools folder.
 $(CONTROLLER_GEN): $(TOOLS_DIR)/go.mod # Build controller-gen from tools folder.
 	cd $(TOOLS_DIR) && go build -tags=tools -o bin/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen
 
-$(GOLANGCI_LINT): .github/workflows/golangci-lint.yml # Download golanci-lint using hack script into tools folder.
-	hack/ensure-golangci-lint.sh \
-		-b $(TOOLS_BIN_DIR) \
-		$(shell cat .github/workflows/golangci-lint.yml | grep "version: v" | sed 's/.*version: //')
+$(GOLANGCI_LINT): .github/workflows/golangci-lint.yml # Download golangci-lint using hack script into tools folder.
+	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(shell cat .github/workflows/golangci-lint.yml | grep "version: v" | sed 's/.*version: //')
+
+.PHONY: tools
+tools: $(GO_APIDIFF) $(CONTROLLER_GEN) $(GOLANGCI_LINT)
 
 ## --------------------------------------
 ## Linting

--- a/examples/scratch-env/go.sum
+++ b/examples/scratch-env/go.sum
@@ -936,6 +936,10 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34 h1:tom0JX5OmAeOOmkGv8LaYHDtA1xAKDiQL5U0vhYYgdM=
+github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34/go.mod h1:cWoaYGHl1nlzdEM2xvMzIASkEZJZLSf5nhe17M7wDhw=
+github.com/kcp-dev/logicalcluster/v3 v3.0.4 h1:q7KngML/QM7sWl8aVzmfZF0TPMnBwYNxsPKfwUvvBvU=
+github.com/kcp-dev/logicalcluster/v3 v3.0.4/go.mod h1:EWBUBxdr49fUB1cLMO4nOdBWmYifLbP1LfoL20KkXYY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/go-logr/zapr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0
+	github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34
+	github.com/kcp-dev/logicalcluster/v3 v3.0.4
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,10 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34 h1:tom0JX5OmAeOOmkGv8LaYHDtA1xAKDiQL5U0vhYYgdM=
+github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34/go.mod h1:cWoaYGHl1nlzdEM2xvMzIASkEZJZLSf5nhe17M7wDhw=
+github.com/kcp-dev/logicalcluster/v3 v3.0.4 h1:q7KngML/QM7sWl8aVzmfZF0TPMnBwYNxsPKfwUvvBvU=
+github.com/kcp-dev/logicalcluster/v3 v3.0.4/go.mod h1:EWBUBxdr49fUB1cLMO4nOdBWmYifLbP1LfoL20KkXYY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -545,13 +546,13 @@ func NonBlockingGetTest(createCacheFunc func(config *rest.Config, opts cache.Opt
 
 			By("creating the informer cache")
 			v := reflect.ValueOf(&opts).Elem()
-			newInformerField := v.FieldByName("newInformer")
-			newFakeInformer := func(_ kcache.ListerWatcher, _ runtime.Object, _ time.Duration, _ kcache.Indexers) kcache.SharedIndexInformer {
+			newInformerField := v.FieldByName("NewInformerFunc")
+			newFakeInformer := func(_ kcache.ListerWatcher, _ runtime.Object, _ time.Duration, _ kcache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 				return &controllertest.FakeInformer{Synced: false}
 			}
 			reflect.NewAt(newInformerField.Type(), newInformerField.Addr().UnsafePointer()).
 				Elem().
-				Set(reflect.ValueOf(&newFakeInformer))
+				Set(reflect.ValueOf(newFakeInformer))
 			informerCache, err = createCacheFunc(cfg, opts)
 			Expect(err).NotTo(HaveOccurred())
 			By("running the cache and waiting for it to sync")

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,6 +32,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/internal/field/selector"
+	"sigs.k8s.io/controller-runtime/pkg/kontext"
 )
 
 // CacheReader is a client.Reader.
@@ -53,11 +56,11 @@ type CacheReader struct {
 }
 
 // Get checks the indexer for the object and writes a copy of it if found.
-func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out client.Object, _ ...client.GetOption) error {
+func (c *CacheReader) Get(ctx context.Context, key client.ObjectKey, out client.Object, _ ...client.GetOption) error {
 	if c.scopeName == apimeta.RESTScopeNameRoot {
 		key.Namespace = ""
 	}
-	storeKey := objectKeyToStoreKey(key)
+	storeKey := objectKeyToStoreKey(ctx, key)
 
 	// Lookup the object from the indexer cache
 	obj, exists, err := c.indexer.GetByKey(storeKey)
@@ -104,7 +107,7 @@ func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out client.Ob
 }
 
 // List lists items out of the indexer and writes them to out.
-func (c *CacheReader) List(_ context.Context, out client.ObjectList, opts ...client.ListOption) error {
+func (c *CacheReader) List(ctx context.Context, out client.ObjectList, opts ...client.ListOption) error {
 	var objs []interface{}
 	var err error
 
@@ -114,6 +117,8 @@ func (c *CacheReader) List(_ context.Context, out client.ObjectList, opts ...cli
 	if listOpts.Continue != "" {
 		return fmt.Errorf("continue list option is not supported by the cache")
 	}
+
+	clusterName, _ := kontext.ClusterFrom(ctx)
 
 	switch {
 	case listOpts.FieldSelector != nil:
@@ -126,11 +131,23 @@ func (c *CacheReader) List(_ context.Context, out client.ObjectList, opts ...cli
 		// list all objects by the field selector. If this is namespaced and we have one, ask for the
 		// namespaced index key. Otherwise, ask for the non-namespaced variant by using the fake "all namespaces"
 		// namespace.
-		objs, err = c.indexer.ByIndex(FieldIndexName(field), KeyToNamespacedKey(listOpts.Namespace, val))
+		if clusterName.Empty() {
+			objs, err = c.indexer.ByIndex(FieldIndexName(field), KeyToNamespacedKey(listOpts.Namespace, val))
+		} else {
+			objs, err = c.indexer.ByIndex(FieldIndexName(field), KeyToClusteredKey(clusterName.String(), listOpts.Namespace, val))
+		}
 	case listOpts.Namespace != "":
-		objs, err = c.indexer.ByIndex(cache.NamespaceIndex, listOpts.Namespace)
+		if clusterName.Empty() {
+			objs, err = c.indexer.ByIndex(cache.NamespaceIndex, listOpts.Namespace)
+		} else {
+			objs, err = c.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(clusterName, listOpts.Namespace))
+		}
 	default:
-		objs = c.indexer.List()
+		if clusterName.Empty() {
+			objs = c.indexer.List()
+		} else {
+			objs, err = c.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(clusterName))
+		}
 	}
 	if err != nil {
 		return err
@@ -182,7 +199,12 @@ func (c *CacheReader) List(_ context.Context, out client.ObjectList, opts ...cli
 // It's akin to MetaNamespaceKeyFunc. It's separate from
 // String to allow keeping the key format easily in sync with
 // MetaNamespaceKeyFunc.
-func objectKeyToStoreKey(k client.ObjectKey) string {
+func objectKeyToStoreKey(ctx context.Context, k client.ObjectKey) string {
+	cluster, ok := kontext.ClusterFrom(ctx)
+	if ok {
+		return kcpcache.ToClusterAwareKey(cluster.String(), k.Namespace, k.Name)
+	}
+
 	if k.Namespace == "" {
 		return k.Name
 	}
@@ -205,4 +227,10 @@ func KeyToNamespacedKey(ns string, baseKey string) string {
 		return ns + "/" + baseKey
 	}
 	return allNamespacesNamespace + "/" + baseKey
+}
+
+// KeyToClusteredKey prefixes the given index key with a cluster name
+// for use in field selector indexes.
+func KeyToClusteredKey(clusterName string, ns string, baseKey string) string {
+	return clusterName + "/" + KeyToNamespacedKey(ns, baseKey)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -89,6 +89,14 @@ type CacheOptions struct {
 // NewClientFunc allows a user to define how to create a client.
 type NewClientFunc func(config *rest.Config, options Options) (Client, error)
 
+// NewAPIReaderFunc allows a user to define how to create an API server reader.
+type NewAPIReaderFunc func(config *rest.Config, options Options) (Reader, error)
+
+// NewAPIReader creates a new API server reader.
+func NewAPIReader(config *rest.Config, options Options) (Reader, error) {
+	return New(config, options)
+}
+
 // New returns a new Client using the provided config and Options.
 // The returned client reads *and* writes directly from the server
 // (it doesn't use object caches).  It understands how to work with

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -18,9 +18,12 @@ package client
 
 import (
 	"context"
+	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,6 +46,10 @@ type Patch interface {
 	// Data is the raw data representing the patch.
 	Data(obj Object) ([]byte, error)
 }
+
+// NewInformerFunc describes a function that creates SharedIndexInformers.
+// Its signature matches cache.NewSharedIndexInformer from client-go.
+type NewInformerFunc func(cache.ListerWatcher, runtime.Object, time.Duration, cache.Indexers) kcpcache.ScopeableSharedIndexInformer
 
 // TODO(directxman12): is there a sane way to deal with get/delete options?
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -121,6 +121,11 @@ type Options struct {
 	// By default, the client will use the cache for reads and direct calls for writes.
 	Client client.Options
 
+	// NewAPIReaderFunc is the function that creates the APIReader client to be
+	// used by the manager. If not set this will use the default new APIReader
+	// function.
+	NewAPIReader client.NewAPIReaderFunc
+
 	// NewClient is the func that creates the client to be used by the manager.
 	// If not set this will create a Client backed by a Cache for read operations
 	// and a direct Client for write operations.
@@ -230,7 +235,7 @@ func New(config *rest.Config, opts ...Option) (Cluster, error) {
 	}
 
 	// Create the API Reader, a client with no cache.
-	clientReader, err := client.New(config, client.Options{
+	clientReader, err := options.NewAPIReader(config, client.Options{
 		HTTPClient: options.HTTPClient,
 		Scheme:     options.Scheme,
 		Mapper:     mapper,
@@ -278,6 +283,10 @@ func setOptionsDefaults(options Options, config *rest.Config) (Options, error) {
 
 	if options.MapperProvider == nil {
 		options.MapperProvider = apiutil.NewDynamicRESTMapper
+	}
+
+	if options.NewAPIReader == nil {
+		options.NewAPIReader = client.NewAPIReader
 	}
 
 	// Allow users to define how to create a new client

--- a/pkg/controller/controllertest/util.go
+++ b/pkg/controller/controllertest/util.go
@@ -19,11 +19,14 @@ package controllertest
 import (
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
 var _ cache.SharedIndexInformer = &FakeInformer{}
+var _ kcpcache.ScopeableSharedIndexInformer = &FakeInformer{}
 
 // FakeInformer provides fake Informer functionality for testing.
 type FakeInformer struct {
@@ -76,6 +79,11 @@ func (e eventHandlerWrapper) OnDelete(obj interface{}) {
 		return
 	}
 	e.handler.(legacyResourceEventHandler).OnDelete(obj)
+}
+
+// Cluster returns the fake Informer.
+func (f *FakeInformer) Cluster(clusterName logicalcluster.Name) cache.SharedIndexInformer {
+	return f
 }
 
 // AddIndexers does nothing.  TODO(community): Implement this.

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -159,9 +161,12 @@ func (e *enqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object, 
 		// object in the event.
 		if ref.Kind == e.groupKind.Kind && refGV.Group == e.groupKind.Group {
 			// Match found - add a Request for the object referred to in the OwnerReference
-			request := reconcile.Request{NamespacedName: types.NamespacedName{
-				Name: ref.Name,
-			}}
+			request := reconcile.Request{
+				ClusterName: logicalcluster.From(object).String(),
+				NamespacedName: types.NamespacedName{
+					Name: ref.Name,
+				},
+			}
 
 			// if owner is not namespaced then we should not set the namespace
 			mapping, err := e.mapper.RESTMapping(e.groupKind, refGV.Version)

--- a/pkg/kcp/wrappers.go
+++ b/pkg/kcp/wrappers.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kcp
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	k8scache "k8s.io/client-go/tools/cache"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/kontext"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/apimachinery/v2/third_party/informers"
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+// NewClusterAwareManager returns a kcp-aware manager with appropriate defaults for cache and
+// client creation.
+func NewClusterAwareManager(cfg *rest.Config, options ctrl.Options) (manager.Manager, error) {
+	if options.NewCache == nil {
+		options.NewCache = NewClusterAwareCache
+	}
+
+	if options.NewAPIReader == nil {
+		options.NewAPIReader = NewClusterAwareAPIReader
+	}
+
+	if options.NewClient == nil {
+		options.NewClient = NewClusterAwareClient
+	}
+
+	if options.MapperProvider == nil {
+		options.MapperProvider = NewClusterAwareMapperProvider
+	}
+
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return newClusterRoundTripper(rt)
+	})
+	return ctrl.NewManager(cfg, options)
+}
+
+// NewClusterAwareCache returns a cache.Cache that handles multi-cluster watches.
+func NewClusterAwareCache(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+	c := rest.CopyConfig(config)
+	c.Host += "/clusters/*"
+	opts.NewInformerFunc = informers.NewSharedIndexInformer
+
+	opts.Indexers = k8scache.Indexers{
+		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
+		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc,
+	}
+	return cache.New(c, opts)
+}
+
+// NewClusterAwareAPIReader returns a client.Reader that provides read-only access to the API server,
+// and is configured to use the context to scope requests to the proper cluster. To scope requests,
+// pass the request context with the cluster set.
+// Example:
+//
+//	import (
+//		"context"
+//		kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
+//		ctrl "sigs.k8s.io/controller-runtime"
+//	)
+//	func (r *reconciler)  Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//		ctx = kcpclient.WithCluster(ctx, req.ObjectKey.Cluster)
+//		// from here on pass this context to all client calls
+//		...
+//	}
+func NewClusterAwareAPIReader(config *rest.Config, opts client.Options) (client.Reader, error) {
+	httpClient, err := ClusterAwareHTTPClient(config)
+	if err != nil {
+		return nil, err
+	}
+	opts.HTTPClient = httpClient
+	return client.NewAPIReader(config, opts)
+}
+
+// NewClusterAwareClient returns a client.Client that is configured to use the context
+// to scope requests to the proper cluster. To scope requests, pass the request context with the cluster set.
+// Example:
+//
+//	import (
+//		"context"
+//		kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
+//		ctrl "sigs.k8s.io/controller-runtime"
+//	)
+//	func (r *reconciler)  Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//		ctx = kcpclient.WithCluster(ctx, req.ObjectKey.Cluster)
+//		// from here on pass this context to all client calls
+//		...
+//	}
+func NewClusterAwareClient(config *rest.Config, opts client.Options) (client.Client, error) {
+	httpClient, err := ClusterAwareHTTPClient(config)
+	if err != nil {
+		return nil, err
+	}
+	opts.HTTPClient = httpClient
+	return client.New(config, opts)
+}
+
+// NewClusterAwareClientForConfig returns a client.Client that is configured to use the context to scope
+// requests to the proper cluster. To scope requests, pass the request context with the cluster set.
+// Example:
+//
+//	import (
+//		"context"
+//		kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
+//		ctrl "sigs.k8s.io/controller-runtime"
+//	)
+//	func (r *reconciler)  Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//		ctx = kcpclient.WithCluster(ctx, req.ObjectKey.Cluster)
+//		// from here on pass this context to all client calls
+//		...
+//	}
+func NewClusterAwareClientForConfig(config *rest.Config, httpClient *http.Client) (client.Client, error) {
+	restMapper, err := NewClusterAwareMapperProvider(config, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return client.New(config, client.Options{
+		Mapper:     restMapper,
+		HTTPClient: httpClient,
+	})
+}
+
+// ClusterAwareHTTPClient returns an http.Client with a cluster aware round tripper.
+func ClusterAwareHTTPClient(config *rest.Config) (*http.Client, error) {
+	httpClient, err := rest.HTTPClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient.Transport = newClusterRoundTripper(httpClient.Transport)
+	return httpClient, nil
+}
+
+// NewClusterAwareMapperProvider is a MapperProvider that returns a logical cluster aware meta.RESTMapper.
+func NewClusterAwareMapperProvider(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+	mapperCfg := rest.CopyConfig(c)
+	if !strings.HasSuffix(mapperCfg.Host, "/clusters/*") {
+		mapperCfg.Host += "/clusters/*"
+	}
+
+	return apiutil.NewDynamicRESTMapper(mapperCfg, httpClient)
+}
+
+// ClusterAwareBuilderWithOptions returns a cluster aware Cache constructor that will build
+// a cache honoring the options argument, this is useful to specify options like
+// SelectorsDefaultNamespaces
+// WARNING: If SelectorsByObject is specified, filtered out resources are not
+// returned.
+// WARNING: If UnsafeDisableDeepCopy is enabled, you must DeepCopy any object
+// returned from cache get/list before mutating it.
+func ClusterAwareBuilderWithOptions(options cache.Options) cache.NewCacheFunc {
+	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+		if options.Scheme == nil {
+			options.Scheme = opts.Scheme
+		}
+		if options.Mapper == nil {
+			options.Mapper = opts.Mapper
+		}
+		if options.SyncPeriod == nil {
+			options.SyncPeriod = opts.SyncPeriod
+		}
+		if opts.DefaultNamespaces == nil {
+			opts.DefaultNamespaces = options.DefaultNamespaces
+		}
+
+		return NewClusterAwareCache(config, options)
+	}
+}
+
+// clusterRoundTripper is a cluster aware wrapper around http.RoundTripper.
+type clusterRoundTripper struct {
+	delegate http.RoundTripper
+}
+
+// newClusterRoundTripper creates a new cluster aware round tripper.
+func newClusterRoundTripper(delegate http.RoundTripper) *clusterRoundTripper {
+	return &clusterRoundTripper{
+		delegate: delegate,
+	}
+}
+
+func (c *clusterRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cluster, ok := kontext.ClusterFrom(req.Context())
+	if ok {
+		req = req.Clone(req.Context())
+		req.URL.Path = generatePath(req.URL.Path, cluster.Path())
+		req.URL.RawPath = generatePath(req.URL.RawPath, cluster.Path())
+	}
+	return c.delegate.RoundTrip(req)
+}
+
+// apiRegex matches any string that has /api/ or /apis/ in it.
+var apiRegex = regexp.MustCompile(`(/api/|/apis/)`)
+
+// generatePath formats the request path to target the specified cluster.
+func generatePath(originalPath string, clusterPath logicalcluster.Path) string {
+	// If the originalPath already has cluster.Path() then the path was already modifed and no change needed
+	if strings.Contains(originalPath, clusterPath.RequestPath()) {
+		return originalPath
+	}
+	// If the originalPath has /api/ or /apis/ in it, it might be anywhere in the path, so we use a regex to find and
+	// replaces /api/ or /apis/ with $cluster/api/ or $cluster/apis/
+	if apiRegex.MatchString(originalPath) {
+		return apiRegex.ReplaceAllString(originalPath, fmt.Sprintf("%s$1", clusterPath.RequestPath()))
+	}
+	// Otherwise, we're just prepending /clusters/$name
+	path := clusterPath.RequestPath()
+	// if the original path is relative, add a / separator
+	if len(originalPath) > 0 && originalPath[0] != '/' {
+		path += "/"
+	}
+	// finally append the original path
+	path += originalPath
+	return path
+}

--- a/pkg/kontext/kontext.go
+++ b/pkg/kontext/kontext.go
@@ -1,0 +1,24 @@
+package kontext
+
+import (
+	"context"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+type key int
+
+const (
+	keyCluster key = iota
+)
+
+// WithCluster injects a cluster name into a context.
+func WithCluster(ctx context.Context, cluster logicalcluster.Name) context.Context {
+	return context.WithValue(ctx, keyCluster, cluster)
+}
+
+// ClusterFrom extracts a cluster name from the context.
+func ClusterFrom(ctx context.Context) (logicalcluster.Name, bool) {
+	s, ok := ctx.Value(keyCluster).(logicalcluster.Name)
+	return s, ok
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -120,6 +120,11 @@ type Options struct {
 	// Only use a custom NewCache if you know what you are doing.
 	NewCache cache.NewCacheFunc
 
+	// NewAPIReaderFunc is the function that creates the APIReader client to be
+	// used by the manager. If not set this will use the default new APIReader
+	// function.
+	NewAPIReader client.NewAPIReaderFunc
+
 	// Client is the client.Options that will be used to create the default Client.
 	// By default, the client will use the cache for reads and direct calls for writes.
 	Client client.Options
@@ -324,6 +329,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		clusterOptions.MapperProvider = options.MapperProvider
 		clusterOptions.Logger = options.Logger
 		clusterOptions.NewCache = options.NewCache
+		clusterOptions.NewAPIReader = options.NewAPIReader
 		clusterOptions.NewClient = options.NewClient
 		clusterOptions.Cache = options.Cache
 		clusterOptions.Client = options.Client

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -48,6 +48,10 @@ func (r *Result) IsZero() bool {
 type Request struct {
 	// NamespacedName is the name and namespace of the object to reconcile.
 	types.NamespacedName
+
+	// ClusterName can be used for reconciling requests across multiple clusters,
+	// to prevent objects with the same name and namespace from conflicting
+	ClusterName string
 }
 
 /*


### PR DESCRIPTION
This PR applies the modifications from the kcp-1.26 branch onto the most recent version (0.16.2), plus it bumps dependencies to Kubernetes 1.28.

Fixes #41 