### PR TITLE
:bug: Re-wire additional indexers into informers creation

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -361,6 +361,7 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 				Transform:             config.Transform,
 				UnsafeDisableDeepCopy: pointer.BoolDeref(config.UnsafeDisableDeepCopy, false),
 				NewInformer:           opts.NewInformerFunc,
+				Indexers:              opts.Indexers,
 			}),
 			readerFailOnMissingInformer: opts.ReaderFailOnMissingInformer,
 		}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

While trying to use `controller-runtime`, I ran into the issue that I couldn't do `List` calls when the logical cluster was set in my `ctx`. The error I got was

> Index with name cluster does not exist

Now I'm not an expert with those kube internals, but I spent some significant time delving into this and I discovered the following: In #10, kcp specific indexers were added. These were wired up properly. It seems we might have lost that in #42 (or maybe before), where the `cache.Options` field `Indexers` still exists but it is unused and therefore  does not reach the part of the code where informers are created.

This PR re-wires the additional indexers and it solved the problem with calling `List`, but I have honestly no idea if it's the best way to do it or if there is some way to pass it already that i missed. The indexers in `addInformerToMap` looked pretty hardcoded to me, but again, limited knowledge.

I hope someone has a good enough understanding of controller-runtime's `cache` package that they can review this properly.