### PR TITLE
:sparkles: Rebase to v0.17.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,5 +22,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.0
+          version: v1.56.2
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,8 +12,8 @@ linters:
     - errorlint
     - exhaustive
     - exportloopref
-    - ginkgolinter
-    - goconst
+    # - ginkgolinter
+    # - goconst
     - gocritic
     - gocyclo
     - gofmt

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,13 @@
+presubmits:
+  - name: pull-controller-runtime-everything
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/controller-runtime.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.20.9-1
+          command:
+            - make
+            - test

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.9-1
-          command:
-            - make
-            - test
+      - image: ghcr.io/kcp-dev/infra/build:1.21.8-1
+        command:
+        - make
+        - test

--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - sttts
+  - xrstf
+  - mjudeikis
+  - embik

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,11 @@ $(GO_APIDIFF): $(TOOLS_DIR)/go.mod # Build go-apidiff from tools folder.
 $(CONTROLLER_GEN): $(TOOLS_DIR)/go.mod # Build controller-gen from tools folder.
 	cd $(TOOLS_DIR) && go build -tags=tools -o bin/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen
 
-$(GOLANGCI_LINT): .github/workflows/golangci-lint.yml # Download golanci-lint using hack script into tools folder.
-	hack/ensure-golangci-lint.sh \
-		-b $(TOOLS_BIN_DIR) \
-		$(shell cat .github/workflows/golangci-lint.yml | grep "version: v" | sed 's/.*version: //')
+$(GOLANGCI_LINT): .github/workflows/golangci-lint.yml # Download golangci-lint using hack script into tools folder.
+	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(shell cat .github/workflows/golangci-lint.yml | grep "version: v" | sed 's/.*version: //')
+
+.PHONY: tools
+tools: $(GO_APIDIFF) $(CONTROLLER_GEN) $(GOLANGCI_LINT)
 
 ## --------------------------------------
 ## Linting

--- a/examples/scratch-env/go.mod
+++ b/examples/scratch-env/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34 // indirect
+	github.com/kcp-dev/logicalcluster/v3 v3.0.4 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/examples/scratch-env/go.sum
+++ b/examples/scratch-env/go.sum
@@ -54,6 +54,10 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34 h1:tom0JX5OmAeOOmkGv8LaYHDtA1xAKDiQL5U0vhYYgdM=
+github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34/go.mod h1:cWoaYGHl1nlzdEM2xvMzIASkEZJZLSf5nhe17M7wDhw=
+github.com/kcp-dev/logicalcluster/v3 v3.0.4 h1:q7KngML/QM7sWl8aVzmfZF0TPMnBwYNxsPKfwUvvBvU=
+github.com/kcp-dev/logicalcluster/v3 v3.0.4/go.mod h1:EWBUBxdr49fUB1cLMO4nOdBWmYifLbP1LfoL20KkXYY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
+	github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34
+	github.com/kcp-dev/logicalcluster/v3 v3.0.4
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,10 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34 h1:tom0JX5OmAeOOmkGv8LaYHDtA1xAKDiQL5U0vhYYgdM=
+github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0.0.20230926071920-57d168bcbe34/go.mod h1:cWoaYGHl1nlzdEM2xvMzIASkEZJZLSf5nhe17M7wDhw=
+github.com/kcp-dev/logicalcluster/v3 v3.0.4 h1:q7KngML/QM7sWl8aVzmfZF0TPMnBwYNxsPKfwUvvBvU=
+github.com/kcp-dev/logicalcluster/v3 v3.0.4/go.mod h1:EWBUBxdr49fUB1cLMO4nOdBWmYifLbP1LfoL20KkXYY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kcp-dev/apimachinery/v2/third_party/informers"
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -170,6 +171,14 @@ type Options struct {
 	// instead of `reconcile.Result{}`.
 	SyncPeriod *time.Duration
 
+	// NewInformerFunc is a function that is used to create SharedIndexInformers.
+	// Defaults to cache.NewSharedIndexInformer from client-go
+	NewInformerFunc client.NewInformerFunc
+
+	// Indexers is the indexers that the informers will be configured to use.
+	// Will always have the standard NamespaceIndex.
+	Indexers toolscache.Indexers
+
 	// ReaderFailOnMissingInformer configures the cache to return a ErrResourceNotCached error when a user
 	// requests, using Get() and List(), a resource the cache does not already have an informer for.
 	//
@@ -223,9 +232,6 @@ type Options struct {
 	// ByObject restricts the cache's ListWatch to the desired fields per GVK at the specified object.
 	// object, this will fall through to Default* settings.
 	ByObject map[client.Object]ByObject
-
-	// newInformer allows overriding of NewSharedIndexInformer for testing.
-	newInformer *func(toolscache.ListerWatcher, runtime.Object, time.Duration, toolscache.Indexers) toolscache.SharedIndexInformer
 }
 
 // ByObject offers more fine-grained control over the cache's ListWatch by object.
@@ -382,7 +388,7 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 				Transform:             config.Transform,
 				WatchErrorHandler:     opts.DefaultWatchErrorHandler,
 				UnsafeDisableDeepCopy: ptr.Deref(config.UnsafeDisableDeepCopy, false),
-				NewInformer:           opts.newInformer,
+				NewInformer:           opts.NewInformerFunc,
 			}),
 			readerFailOnMissingInformer: opts.ReaderFailOnMissingInformer,
 		}
@@ -477,6 +483,10 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 	// Default the resync period to 10 hours if unset
 	if opts.SyncPeriod == nil {
 		opts.SyncPeriod = &defaultSyncPeriod
+	}
+
+	if opts.NewInformerFunc == nil {
+		opts.NewInformerFunc = informers.NewSharedIndexInformer
 	}
 	return opts, nil
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -545,13 +546,13 @@ func NonBlockingGetTest(createCacheFunc func(config *rest.Config, opts cache.Opt
 
 			By("creating the informer cache")
 			v := reflect.ValueOf(&opts).Elem()
-			newInformerField := v.FieldByName("newInformer")
-			newFakeInformer := func(_ kcache.ListerWatcher, _ runtime.Object, _ time.Duration, _ kcache.Indexers) kcache.SharedIndexInformer {
+			newInformerField := v.FieldByName("NewInformerFunc")
+			newFakeInformer := func(_ kcache.ListerWatcher, _ runtime.Object, _ time.Duration, _ kcache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 				return &controllertest.FakeInformer{Synced: false}
 			}
 			reflect.NewAt(newInformerField.Type(), newInformerField.Addr().UnsafePointer()).
 				Elem().
-				Set(reflect.ValueOf(&newFakeInformer))
+				Set(reflect.ValueOf(newFakeInformer))
 			informerCache, err = createCacheFunc(cfg, opts)
 			Expect(err).NotTo(HaveOccurred())
 			By("running the cache and waiting for it to sync")

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -31,6 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache/internal"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"github.com/kcp-dev/logicalcluster/v3"
 )
 
 var (
@@ -233,6 +235,13 @@ func indexByField(informer Informer, field string, extractValue client.IndexerFu
 		}
 		ns := meta.GetNamespace()
 
+		keyFunc := internal.KeyToNamespacedKey
+		if clusterName := logicalcluster.From(obj); !clusterName.Empty() {
+			keyFunc = func(ns, val string) string {
+				return internal.KeyToClusteredKey(clusterName.String(), ns, val)
+			}
+		}
+
 		rawVals := extractValue(obj)
 		var vals []string
 		if ns == "" {
@@ -242,14 +251,15 @@ func indexByField(informer Informer, field string, extractValue client.IndexerFu
 			// if we need to add non-namespaced versions too, double the length
 			vals = make([]string, len(rawVals)*2)
 		}
+
 		for i, rawVal := range rawVals {
 			// save a namespaced variant, so that we can ask
 			// "what are all the object matching a given index *in a given namespace*"
-			vals[i] = internal.KeyToNamespacedKey(ns, rawVal)
+			vals[i] = keyFunc(ns, rawVal)
 			if ns != "" {
 				// if we have a namespace, also inject a special index key for listing
 				// regardless of the object namespace
-				vals[i+len(rawVals)] = internal.KeyToNamespacedKey("", rawVal)
+				vals[i+len(rawVals)] = keyFunc("", rawVal)
 			}
 		}
 

--- a/pkg/cache/internal/informers.go
+++ b/pkg/cache/internal/informers.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/apimachinery/v2/third_party/informers"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +48,7 @@ type InformersOpts struct {
 	Mapper                meta.RESTMapper
 	ResyncPeriod          time.Duration
 	Namespace             string
-	NewInformer           *func(cache.ListerWatcher, runtime.Object, time.Duration, cache.Indexers) cache.SharedIndexInformer
+	NewInformer           func(cache.ListerWatcher, runtime.Object, time.Duration, cache.Indexers) kcpcache.ScopeableSharedIndexInformer
 	Selector              Selector
 	Transform             cache.TransformFunc
 	UnsafeDisableDeepCopy bool
@@ -55,9 +57,9 @@ type InformersOpts struct {
 
 // NewInformers creates a new InformersMap that can create informers under the hood.
 func NewInformers(config *rest.Config, options *InformersOpts) *Informers {
-	newInformer := cache.NewSharedIndexInformer
+	newInformer := informers.NewSharedIndexInformer
 	if options.NewInformer != nil {
-		newInformer = *options.NewInformer
+		newInformer = options.NewInformer
 	}
 	return &Informers{
 		config:     config,
@@ -175,7 +177,7 @@ type Informers struct {
 	unsafeDisableDeepCopy bool
 
 	// NewInformer allows overriding of the shared index informer constructor for testing.
-	newInformer func(cache.ListerWatcher, runtime.Object, time.Duration, cache.Indexers) cache.SharedIndexInformer
+	newInformer func(cache.ListerWatcher, runtime.Object, time.Duration, cache.Indexers) kcpcache.ScopeableSharedIndexInformer
 
 	// WatchErrorHandler allows the shared index informer's
 	// watchErrorHandler to be set by overriding the options

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -89,6 +89,14 @@ type CacheOptions struct {
 // NewClientFunc allows a user to define how to create a client.
 type NewClientFunc func(config *rest.Config, options Options) (Client, error)
 
+// NewAPIReaderFunc allows a user to define how to create an API server reader.
+type NewAPIReaderFunc func(config *rest.Config, options Options) (Reader, error)
+
+// NewAPIReader creates a new API server reader.
+func NewAPIReader(config *rest.Config, options Options) (Reader, error) {
+	return New(config, options)
+}
+
 // New returns a new Client using the provided config and Options.
 //
 // The client's read behavior is determined by Options.Cache.

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -18,9 +18,12 @@ package client
 
 import (
 	"context"
+	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,6 +46,10 @@ type Patch interface {
 	// Data is the raw data representing the patch.
 	Data(obj Object) ([]byte, error)
 }
+
+// NewInformerFunc describes a function that creates SharedIndexInformers.
+// Its signature matches cache.NewSharedIndexInformer from client-go.
+type NewInformerFunc func(cache.ListerWatcher, runtime.Object, time.Duration, cache.Indexers) kcpcache.ScopeableSharedIndexInformer
 
 // TODO(directxman12): is there a sane way to deal with get/delete options?
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -121,6 +121,11 @@ type Options struct {
 	// By default, the client will use the cache for reads and direct calls for writes.
 	Client client.Options
 
+	// NewAPIReaderFunc is the function that creates the APIReader client to be
+	// used by the manager. If not set this will use the default new APIReader
+	// function.
+	NewAPIReader client.NewAPIReaderFunc
+
 	// NewClient is the func that creates the client to be used by the manager.
 	// If not set this will create a Client backed by a Cache for read operations
 	// and a direct Client for write operations.
@@ -230,7 +235,7 @@ func New(config *rest.Config, opts ...Option) (Cluster, error) {
 	}
 
 	// Create the API Reader, a client with no cache.
-	clientReader, err := client.New(config, client.Options{
+	clientReader, err := options.NewAPIReader(config, client.Options{
 		HTTPClient: options.HTTPClient,
 		Scheme:     options.Scheme,
 		Mapper:     mapper,
@@ -278,6 +283,10 @@ func setOptionsDefaults(options Options, config *rest.Config) (Options, error) {
 
 	if options.MapperProvider == nil {
 		options.MapperProvider = apiutil.NewDynamicRESTMapper
+	}
+
+	if options.NewAPIReader == nil {
+		options.NewAPIReader = client.NewAPIReader
 	}
 
 	// Allow users to define how to create a new client

--- a/pkg/controller/controllertest/util.go
+++ b/pkg/controller/controllertest/util.go
@@ -19,11 +19,14 @@ package controllertest
 import (
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
 var _ cache.SharedIndexInformer = &FakeInformer{}
+var _ kcpcache.ScopeableSharedIndexInformer = &FakeInformer{}
 
 // FakeInformer provides fake Informer functionality for testing.
 type FakeInformer struct {
@@ -76,6 +79,11 @@ func (e eventHandlerWrapper) OnDelete(obj interface{}) {
 		return
 	}
 	e.handler.(legacyResourceEventHandler).OnDelete(obj)
+}
+
+// Cluster returns the fake Informer.
+func (f *FakeInformer) Cluster(clusterName logicalcluster.Name) cache.SharedIndexInformer {
+	return f
 }
 
 // AddIndexers does nothing.  TODO(community): Implement this.

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -159,9 +161,12 @@ func (e *enqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object, 
 		// object in the event.
 		if ref.Kind == e.groupKind.Kind && refGV.Group == e.groupKind.Group {
 			// Match found - add a Request for the object referred to in the OwnerReference
-			request := reconcile.Request{NamespacedName: types.NamespacedName{
-				Name: ref.Name,
-			}}
+			request := reconcile.Request{
+				ClusterName: logicalcluster.From(object).String(),
+				NamespacedName: types.NamespacedName{
+					Name: ref.Name,
+				},
+			}
 
 			// if owner is not namespaced then we should not set the namespace
 			mapping, err := e.mapper.RESTMapping(e.groupKind, refGV.Version)

--- a/pkg/kcp/wrappers.go
+++ b/pkg/kcp/wrappers.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kcp
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	k8scache "k8s.io/client-go/tools/cache"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/kontext"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/apimachinery/v2/third_party/informers"
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+// NewClusterAwareManager returns a kcp-aware manager with appropriate defaults for cache and
+// client creation.
+func NewClusterAwareManager(cfg *rest.Config, options ctrl.Options) (manager.Manager, error) {
+	if options.NewCache == nil {
+		options.NewCache = NewClusterAwareCache
+	}
+
+	if options.NewAPIReader == nil {
+		options.NewAPIReader = NewClusterAwareAPIReader
+	}
+
+	if options.NewClient == nil {
+		options.NewClient = NewClusterAwareClient
+	}
+
+	if options.MapperProvider == nil {
+		options.MapperProvider = NewClusterAwareMapperProvider
+	}
+
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return newClusterRoundTripper(rt)
+	})
+	return ctrl.NewManager(cfg, options)
+}
+
+// NewClusterAwareCache returns a cache.Cache that handles multi-cluster watches.
+func NewClusterAwareCache(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+	c := rest.CopyConfig(config)
+	c.Host += "/clusters/*"
+
+	opts.NewInformerFunc = func(lw k8scache.ListerWatcher, obj runtime.Object, syncPeriod time.Duration, indexers k8scache.Indexers) kcpcache.ScopeableSharedIndexInformer {
+		indexers[kcpcache.ClusterIndexName] = kcpcache.ClusterIndexFunc
+		indexers[kcpcache.ClusterAndNamespaceIndexName] = kcpcache.ClusterAndNamespaceIndexFunc
+
+		return informers.NewSharedIndexInformer(lw, obj, syncPeriod, indexers)
+	}
+
+	return cache.New(c, opts)
+}
+
+// NewClusterAwareAPIReader returns a client.Reader that provides read-only access to the API server,
+// and is configured to use the context to scope requests to the proper cluster. To scope requests,
+// pass the request context with the cluster set.
+// Example:
+//
+//	import (
+//		"context"
+//		kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
+//		ctrl "sigs.k8s.io/controller-runtime"
+//	)
+//	func (r *reconciler)  Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//		ctx = kcpclient.WithCluster(ctx, req.ObjectKey.Cluster)
+//		// from here on pass this context to all client calls
+//		...
+//	}
+func NewClusterAwareAPIReader(config *rest.Config, opts client.Options) (client.Reader, error) {
+	httpClient, err := ClusterAwareHTTPClient(config)
+	if err != nil {
+		return nil, err
+	}
+	opts.HTTPClient = httpClient
+	return client.NewAPIReader(config, opts)
+}
+
+// NewClusterAwareClient returns a client.Client that is configured to use the context
+// to scope requests to the proper cluster. To scope requests, pass the request context with the cluster set.
+// Example:
+//
+//	import (
+//		"context"
+//		kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
+//		ctrl "sigs.k8s.io/controller-runtime"
+//	)
+//	func (r *reconciler)  Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//		ctx = kcpclient.WithCluster(ctx, req.ObjectKey.Cluster)
+//		// from here on pass this context to all client calls
+//		...
+//	}
+func NewClusterAwareClient(config *rest.Config, opts client.Options) (client.Client, error) {
+	httpClient, err := ClusterAwareHTTPClient(config)
+	if err != nil {
+		return nil, err
+	}
+	opts.HTTPClient = httpClient
+	return client.New(config, opts)
+}
+
+// NewClusterAwareClientForConfig returns a client.Client that is configured to use the context to scope
+// requests to the proper cluster. To scope requests, pass the request context with the cluster set.
+// Example:
+//
+//	import (
+//		"context"
+//		kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
+//		ctrl "sigs.k8s.io/controller-runtime"
+//	)
+//	func (r *reconciler)  Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//		ctx = kcpclient.WithCluster(ctx, req.ObjectKey.Cluster)
+//		// from here on pass this context to all client calls
+//		...
+//	}
+func NewClusterAwareClientForConfig(config *rest.Config, httpClient *http.Client) (client.Client, error) {
+	restMapper, err := NewClusterAwareMapperProvider(config, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return client.New(config, client.Options{
+		Mapper:     restMapper,
+		HTTPClient: httpClient,
+	})
+}
+
+// ClusterAwareHTTPClient returns an http.Client with a cluster aware round tripper.
+func ClusterAwareHTTPClient(config *rest.Config) (*http.Client, error) {
+	httpClient, err := rest.HTTPClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient.Transport = newClusterRoundTripper(httpClient.Transport)
+	return httpClient, nil
+}
+
+// NewClusterAwareMapperProvider is a MapperProvider that returns a logical cluster aware meta.RESTMapper.
+func NewClusterAwareMapperProvider(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+	mapperCfg := rest.CopyConfig(c)
+	if !strings.HasSuffix(mapperCfg.Host, "/clusters/*") {
+		mapperCfg.Host += "/clusters/*"
+	}
+
+	return apiutil.NewDynamicRESTMapper(mapperCfg, httpClient)
+}
+
+// ClusterAwareBuilderWithOptions returns a cluster aware Cache constructor that will build
+// a cache honoring the options argument, this is useful to specify options like
+// SelectorsDefaultNamespaces
+// WARNING: If SelectorsByObject is specified, filtered out resources are not
+// returned.
+// WARNING: If UnsafeDisableDeepCopy is enabled, you must DeepCopy any object
+// returned from cache get/list before mutating it.
+func ClusterAwareBuilderWithOptions(options cache.Options) cache.NewCacheFunc {
+	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+		if options.Scheme == nil {
+			options.Scheme = opts.Scheme
+		}
+		if options.Mapper == nil {
+			options.Mapper = opts.Mapper
+		}
+		if options.SyncPeriod == nil {
+			options.SyncPeriod = opts.SyncPeriod
+		}
+		if opts.DefaultNamespaces == nil {
+			opts.DefaultNamespaces = options.DefaultNamespaces
+		}
+
+		return NewClusterAwareCache(config, options)
+	}
+}
+
+// clusterRoundTripper is a cluster aware wrapper around http.RoundTripper.
+type clusterRoundTripper struct {
+	delegate http.RoundTripper
+}
+
+// newClusterRoundTripper creates a new cluster aware round tripper.
+func newClusterRoundTripper(delegate http.RoundTripper) *clusterRoundTripper {
+	return &clusterRoundTripper{
+		delegate: delegate,
+	}
+}
+
+func (c *clusterRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cluster, ok := kontext.ClusterFrom(req.Context())
+	if ok {
+		req = req.Clone(req.Context())
+		req.URL.Path = generatePath(req.URL.Path, cluster.Path())
+		req.URL.RawPath = generatePath(req.URL.RawPath, cluster.Path())
+	}
+	return c.delegate.RoundTrip(req)
+}
+
+// apiRegex matches any string that has /api/ or /apis/ in it.
+var apiRegex = regexp.MustCompile(`(/api/|/apis/)`)
+
+// generatePath formats the request path to target the specified cluster.
+func generatePath(originalPath string, clusterPath logicalcluster.Path) string {
+	// If the originalPath already has cluster.Path() then the path was already modifed and no change needed
+	if strings.Contains(originalPath, clusterPath.RequestPath()) {
+		return originalPath
+	}
+	// If the originalPath has /api/ or /apis/ in it, it might be anywhere in the path, so we use a regex to find and
+	// replaces /api/ or /apis/ with $cluster/api/ or $cluster/apis/
+	if apiRegex.MatchString(originalPath) {
+		return apiRegex.ReplaceAllString(originalPath, fmt.Sprintf("%s$1", clusterPath.RequestPath()))
+	}
+	// Otherwise, we're just prepending /clusters/$name
+	path := clusterPath.RequestPath()
+	// if the original path is relative, add a / separator
+	if len(originalPath) > 0 && originalPath[0] != '/' {
+		path += "/"
+	}
+	// finally append the original path
+	path += originalPath
+	return path
+}

--- a/pkg/kontext/kontext.go
+++ b/pkg/kontext/kontext.go
@@ -1,0 +1,24 @@
+package kontext
+
+import (
+	"context"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+type key int
+
+const (
+	keyCluster key = iota
+)
+
+// WithCluster injects a cluster name into a context.
+func WithCluster(ctx context.Context, cluster logicalcluster.Name) context.Context {
+	return context.WithValue(ctx, keyCluster, cluster)
+}
+
+// ClusterFrom extracts a cluster name from the context.
+func ClusterFrom(ctx context.Context) (logicalcluster.Name, bool) {
+	s, ok := ctx.Value(keyCluster).(logicalcluster.Name)
+	return s, ok
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -120,6 +120,11 @@ type Options struct {
 	// Only use a custom NewCache if you know what you are doing.
 	NewCache cache.NewCacheFunc
 
+	// NewAPIReaderFunc is the function that creates the APIReader client to be
+	// used by the manager. If not set this will use the default new APIReader
+	// function.
+	NewAPIReader client.NewAPIReaderFunc
+
 	// Client is the client.Options that will be used to create the default Client.
 	// By default, the client will use the cache for reads and direct calls for writes.
 	Client client.Options
@@ -324,6 +329,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		clusterOptions.MapperProvider = options.MapperProvider
 		clusterOptions.Logger = options.Logger
 		clusterOptions.NewCache = options.NewCache
+		clusterOptions.NewAPIReader = options.NewAPIReader
 		clusterOptions.NewClient = options.NewClient
 		clusterOptions.Cache = options.Cache
 		clusterOptions.Client = options.Client

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -50,6 +50,10 @@ func (r *Result) IsZero() bool {
 type Request struct {
 	// NamespacedName is the name and namespace of the object to reconcile.
 	types.NamespacedName
+
+	// ClusterName can be used for reconciling requests across multiple clusters,
+	// to prevent objects with the same name and namespace from conflicting
+	ClusterName string
 }
 
 /*


### PR DESCRIPTION
Forked v0.17.2 as `kcp-0.17` and cherry-picked the kcp commit from kcp-1.28 branch.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->