### PR TITLE
:bug: UPSTREAM: <carry>: only call cluster-aware keyFunc for cluster-aware cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"golang.org/x/exp/maps"
@@ -390,6 +391,7 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 				NewInformer:           opts.NewInformerFunc,
 			}),
 			readerFailOnMissingInformer: opts.ReaderFailOnMissingInformer,
+			clusterIndexes:              strings.HasSuffix(restConfig.Host, "/clusters/*"),
 		}
 	}
 }

--- a/pkg/cache/kcp_test.go
+++ b/pkg/cache/kcp_test.go
@@ -22,69 +22,117 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("KCP cluster-unaware informer cache", func() {
-	// Test whether we can have a cluster-unaware informer cache against a single workspace.
-	// I.e. every object has a kcp.io/cluster annotation, but it should not be taken
-	// into consideration by the cache to compute the key.
-	It("should be able to get the default namespace despite kcp.io/cluster annotation", func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		c, err := cache.New(cfg, cache.Options{})
-		Expect(err).NotTo(HaveOccurred())
-
+var _ = Describe("informer cache against a kube cluster", func() {
+	BeforeEach(func() {
 		By("Annotating the default namespace with kcp.io/cluster")
 		cl, err := client.New(cfg, client.Options{})
 		Expect(err).NotTo(HaveOccurred())
 		ns := &corev1.Namespace{}
-		err = cl.Get(ctx, client.ObjectKey{Name: "default"}, ns)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: "default"}, ns)
 		Expect(err).NotTo(HaveOccurred())
 		ns.Annotations = map[string]string{"kcp.io/cluster": "cluster1"}
-		err = cl.Update(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
-
-		go c.Start(ctx) //nolint:errcheck // Start is blocking, and error not relevant here.
-		c.WaitForCacheSync(ctx)
-
-		By("By getting the default namespace with the informer")
-		err = c.Get(ctx, client.ObjectKey{Name: "default"}, ns)
+		err = cl.Update(context.Background(), ns)
 		Expect(err).NotTo(HaveOccurred())
 	})
-})
 
-// TODO: get envtest in place with kcp
-/*
-var _ = Describe("KCP cluster-aware informer cache", func() {
-	It("should be able to get the default namespace with kcp.io/cluster annotation", func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	Describe("KCP cluster-unaware informer cache", func() {
+		// Test whether we can have a cluster-unaware informer cache against a single workspace.
+		// I.e. every object has a kcp.io/cluster annotation, but it should not be taken
+		// into consideration by the cache to compute the key.
+		It("should be able to get the default namespace despite kcp.io/cluster annotation", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-		c, err := kcp.NewClusterAwareCache(cfg, cache.Options{})
-		Expect(err).NotTo(HaveOccurred())
+			c, err := cache.New(cfg, cache.Options{})
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Annotating the default namespace with kcp.io/cluster")
-		cl, err := client.New(cfg, client.Options{})
-		Expect(err).NotTo(HaveOccurred())
-		ns := &corev1.Namespace{}
-		err = cl.Get(ctx, client.ObjectKey{Name: "default"}, ns)
-		Expect(err).NotTo(HaveOccurred())
-		ns.Annotations = map[string]string{"kcp.io/cluster": "cluster1"}
-		err = cl.Update(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+			go c.Start(ctx) //nolint:errcheck // Start is blocking, and error not relevant here.
+			c.WaitForCacheSync(ctx)
 
-		go c.Start(ctx) //nolint:errcheck // Start is blocking, and error not relevant here.
-		c.WaitForCacheSync(ctx)
+			By("By getting the default namespace with the informer")
+			ns := &corev1.Namespace{}
+			err = c.Get(ctx, client.ObjectKey{Name: "default"}, ns)
+			Expect(err).NotTo(HaveOccurred())
+		})
 
-		By("By getting the default namespace with the informer, but cluster-less key should fail")
-		err = c.Get(ctx, client.ObjectKey{Name: "default"}, ns)
-		Expect(err).To(HaveOccurred())
+		It("should support indexes with cluster-less keys", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-		By("By getting the default namespace with the informer, but cluster-aware key should succeed")
-		err = c.Get(kontext.WithCluster(ctx, "cluster1"), client.ObjectKey{Name: "default", Namespace: "cluster1"}, ns)
+			c, err := cache.New(cfg, cache.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Indexing the default namespace by name")
+			err = c.IndexField(ctx, &corev1.Namespace{}, "name-clusterless", func(obj client.Object) []string {
+				return []string{"key-" + obj.GetName()}
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			go c.Start(ctx) //nolint:errcheck // Start is blocking, and error not relevant here.
+			c.WaitForCacheSync(ctx)
+
+			By("By getting the default namespace via the custom index")
+			nss := &corev1.NamespaceList{}
+			err = c.List(ctx, nss, client.MatchingFieldsSelector{
+				Selector: fields.OneTermEqualSelector("name-clusterless", "key-default"),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nss.Items).To(HaveLen(1))
+		})
 	})
+
+	// TODO: get envtest in place with kcp
+	/*
+		Describe("KCP cluster-aware informer cache", func() {
+			It("should be able to get the default namespace with kcp.io/cluster annotation", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				c, err := kcp.NewClusterAwareCache(cfg, cache.Options{})
+				Expect(err).NotTo(HaveOccurred())
+
+				go c.Start(ctx) //nolint:errcheck // Start is blocking, and error not relevant here.
+				c.WaitForCacheSync(ctx)
+
+				By("By getting the default namespace with the informer, but cluster-less key should fail")
+				ns := &corev1.Namespace{}
+				err = c.Get(ctx, client.ObjectKey{Name: "default"}, ns)
+				Expect(err).To(HaveOccurred())
+
+				By("By getting the default namespace with the informer, but cluster-aware key should succeed")
+				err = c.Get(kontext.WithCluster(ctx, "cluster1"), client.ObjectKey{Name: "default", Namespace: "cluster1"}, ns)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should support indexes with cluster-aware keys", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				c, err := kcp.NewClusterAwareCache(cfg, cache.Options{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Indexing the default namespace by name")
+				err = c.IndexField(ctx, &corev1.Namespace{}, "name-clusteraware", func(obj client.Object) []string {
+					return []string{"key-" + obj.GetName()}
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				go c.Start(ctx) //nolint:errcheck // Start is blocking, and error not relevant here.
+				c.WaitForCacheSync(ctx)
+
+				By("By getting the default namespace via the custom index")
+				nss := &corev1.NamespaceList{}
+				err = c.List(ctx, nss, client.MatchingFieldsSelector{
+					Selector: fields.OneTermEqualSelector("name-clusteraware", "key-default"),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nss.Items).To(HaveLen(1))
+			})
+		})
+	*/
 })
-*/


### PR DESCRIPTION
In non-cluster-aware case (with normal kubeconfig against kube or one workspace), we should not call the cluster-aware `keyFunc`.

Thanks to @turkenh for finding this bug.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->