### PR TITLE
✨ Prepare context with cluster

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/kcp-dev/logicalcluster/v3"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -31,6 +32,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/kontext"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -309,6 +311,7 @@ func (c *Controller) reconcileHandler(ctx context.Context, obj interface{}) {
 	log = log.WithValues("reconcileID", reconcileID)
 	ctx = logf.IntoContext(ctx, log)
 	ctx = addReconcileID(ctx, reconcileID)
+	ctx = kontext.WithCluster(ctx, logicalcluster.Name(req.ClusterName))
 
 	// RunInformersAndControllers the syncHandler, passing it the Namespace/Name string of the
 	// resource to be synced.


### PR DESCRIPTION
The goal of this is to have the context ready to be used by the time `Reconcile` is called on a controller. I've been seeing lots of code like this:
```
func (m *myCtrl) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
	path := logicalcluster.Name(req.ClusterName).Path()
	clusterCtx := kontext.WithCluster(ctx, logicalcluster.Name(path.String()))
	myType := &foo.MyType{}
	err := m.Get(clusterCtx, types.NamespacedName{Namespace: req.Namespace, Name: req.Name}, myType)
	...
}		
```

I don't see why controllers need to do this over and over. With the context having the cluster set this repetitive boilerplate can be eliminated to something like:
```
func (m *myCtrl) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
	myType := &foo.MyType{}
	err := m.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: req.Name}, myType)
	...
}
```